### PR TITLE
Fix Ankama and Image-Line update dates

### DIFF
--- a/data/companies/ankama.md
+++ b/data/companies/ankama.md
@@ -5,7 +5,7 @@ tags:
 - permanent_id
 logo: png
 name_in_logo: yes
-updated: 2021-30-01
+updated: 2021-01-30
 defaultLang: en
 ---
 

--- a/data/companies/image-line.md
+++ b/data/companies/image-line.md
@@ -4,7 +4,7 @@ tags:
 - ask_for_papers
 - profile_comments
 logo: png
-updated: 2021-30-01
+updated: 2021-01-30
 defaultLang: en
 ---
 


### PR DESCRIPTION
## Problem

Currently, on the live website, Ankama and Image-Line are updated in the future (1st of June 2023). 

![image](https://user-images.githubusercontent.com/1648861/137897918-b216c32c-7e60-4de6-8a61-d2ee84f2590d.png)

This is caused by an inversion of the day and month of the update dates, which is then handled by mutter in a way that for every year with more than 12 month increment the initial year (which makes sense in the context of the library, but make such mistakes hard to catch).

## Solution

This PR is only about fixing the inverted data, which solve the issue

## Remarks

I check all the remaining data just in case, and only theses two were obviously wrong.

the followings are uncheckable (day number under 12) but looks right as close to the commit date

- changemy.name/data/companies/adobe.md
- changemy.name/data/companies/boursorama-banque.md
- changemy.name/data/companies/bouygues-telecom-fr.md
- changemy.name/data/companies/ikea.md
- changemy.name/data/companies/ldlc.md
- changemy.name/data/companies/linkedin.md
- changemy.name/data/companies/nickel.md

and only the scaleway one is uncheckable withou more information, and seems far from the commit date (`changemy.name/data/companies/scaleway.md`)